### PR TITLE
BLD: Drop support for Python 3.8 - 3.10

### DIFF
--- a/.github/workflows/runrms.yml
+++ b/.github/workflows/runrms.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout commit locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ write_to = "src/runrms/version.py"
 name = "runrms"
 description = "A utility to open and run AspenTech's RMS application."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = { text = "GPL-3.0" }
 authors = [
     { name = "Equinor", email = "fg-fmu_atlas@equinor.com" },
@@ -21,9 +21,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Natural Language :: English",


### PR DESCRIPTION
This package currently needs to support Python 3.11 as the minimum version. A dependency will soon drop support for older versions.