### PR TITLE
DEP: Remove 'restricted' option

### DIFF
--- a/src/runrms/config/_site_config.py
+++ b/src/runrms/config/_site_config.py
@@ -22,7 +22,6 @@ class Env(BaseModel):
 class Version(BaseModel):
     """Information about different RMS versions."""
 
-    restricted: bool = Field(default=False)
     env: Env
 
 

--- a/tests/test_rms_config.py
+++ b/tests/test_rms_config.py
@@ -92,7 +92,6 @@ def test_init_rmsconfig_default() -> None:
     config = RMSConfig()
     assert config.version == config_yml["default"]
     assert config.site_config.exe == config_yml["exe"]
-    assert config.version_config.restricted is False
 
 
 def test_init_rmsconfig_default_version(default_config_file) -> None:


### PR DESCRIPTION
Resolves #5 

This option was made available for one particular version and this version is no longer used. Restricted versions are better restricted by not being present in the configuration. This did not actually do anything in the code.