### PR TITLE
ENH: Add information on random seeds file to validation error message

### DIFF
--- a/src/runrms/config/fm_rms_config.py
+++ b/src/runrms/config/fm_rms_config.py
@@ -201,9 +201,11 @@ class FMRMSConfig(RMSConfig):
         file_desc = "Multi seed file" if is_multi else "Single seed file"
         file_desc += f" {filename.absolute()}"
         single_format_desc = "The file must contain one number"
-        multi_format_desc = "The file contents must be unique numbers, one per line. "
-        multi_format_desc += "The first line must have a count of the total numbers in "
-        multi_format_desc += "the file, excluding the count value itself"
+        multi_format_desc = (
+            "The file contents must be unique numbers, one per line. "
+            "The first line must have a count of the total numbers in "
+            "the file, excluding the count value itself"
+        )
         format_desc = multi_format_desc if is_multi else single_format_desc
 
         line_count = len(lines)

--- a/src/runrms/config/fm_rms_config.py
+++ b/src/runrms/config/fm_rms_config.py
@@ -196,10 +196,10 @@ class FMRMSConfig(RMSConfig):
 
     @staticmethod
     def _validate_seed_source(
-        lines: list[str], filename: str, is_multi: bool, iens_max: int | None = None
+        lines: list[str], filename: Path, is_multi: bool, iens_max: int | None = None
     ) -> None:
         file_desc = "Multi seed file" if is_multi else "Single seed file"
-        file_desc += f" {filename}"
+        file_desc += f" {filename.absolute()}"
         single_format_desc = "The file must contain one number"
         multi_format_desc = "The file contents must be unique numbers, one per line. "
         multi_format_desc += "The first line must have a count of the total numbers in "

--- a/tests/test_ert_fm_plugins.py
+++ b/tests/test_ert_fm_plugins.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import subprocess
 
@@ -93,8 +94,8 @@ def test_rms_forward_model_seed_invalid(
         ["ert", "test_run", "snakeoil.ert"], capture_output=True, text=True
     )
 
-    assert (
+    assert re.search(
         "Forward model step pre-experiment validation failed: "
-        + "FMRMSConfig: Multi seed file contains non-number values"
-        in output.stderr
+        + r"FMRMSConfig: Multi seed file \S+ contains non-number values",
+        output.stderr,
     )

--- a/tests/test_fm_rms_config.py
+++ b/tests/test_fm_rms_config.py
@@ -92,11 +92,11 @@ def test_multi_seed_ok(fm_executor_env, iens, expected_result):
 @pytest.mark.parametrize(
     "contents, expected_error",
     [
-        ("", "Single seed file run_path/RMS_SEED is empty"),
-        ("text", "Single seed file run_path/RMS_SEED contains non-number values"),
+        ("", r"Single seed file \S+ is empty"),
+        ("text", r"Single seed file \S+ contains non-number values"),
         (
             "\n".join(["1000", "1001"]),
-            "Single seed file run_path/RMS_SEED contains multiple seed values",
+            r"Single seed file \S+ contains multiple seed values",
         ),
     ],
 )
@@ -112,28 +112,24 @@ def test_single_seed_invalid(fm_executor_env, contents, expected_error):
 @pytest.mark.parametrize(
     "contents, iens, expected_error",
     [
-        ([""], 0, "Multi seed file run_path/random.seeds is empty"),
-        (
-            ["1", "text"],
-            0,
-            "Multi seed file run_path/random.seeds contains non-number values",
-        ),
+        ([""], 0, r"Multi seed file \S+ is empty"),
+        (["1", "text"], 0, r"Multi seed file \S+ contains non-number values"),
         (
             ["2", "1000"],
             0,
-            "Multi seed file run_path/random.seeds has an incorrect "
-            + "number count value in line 1, expected 1 but found 2",
+            r"Multi seed file \S+ has an incorrect number count value "
+            + "in line 1, expected 1 but found 2",
         ),
-        (["0"], 0, "Multi seed file run_path/random.seeds has no seed values"),
+        (["0"], 0, r"Multi seed file \S+ has no seed values"),
         (
             ["2", "1000", "1000"],
             0,
-            "Multi seed file run_path/random.seeds contains non-unique seed values",
+            r"Multi seed file \S+ contains non-unique seed values",
         ),
         (
             ["1", "1000"],
             1,
-            r"Multi seed file run_path/random.seeds has too few seed values \(1\) "
+            r"Multi seed file \S+ has too few seed values \(1\) "
             + r"for the needed realization number \(2\)",
         ),
     ],

--- a/tests/test_fm_rms_config.py
+++ b/tests/test_fm_rms_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from unittest.mock import Mock
 
 import pytest
@@ -93,9 +92,12 @@ def test_multi_seed_ok(fm_executor_env, iens, expected_result):
 @pytest.mark.parametrize(
     "contents, expected_error",
     [
-        ("", "Single seed file is empty"),
-        ("text", "Single seed file contains non-number values"),
-        ("\n".join(["1000", "1001"]), "Single seed file contains multiple seed values"),
+        ("", "Single seed file run_path/RMS_SEED is empty"),
+        ("text", "Single seed file run_path/RMS_SEED contains non-number values"),
+        (
+            "\n".join(["1000", "1001"]),
+            "Single seed file run_path/RMS_SEED contains multiple seed values",
+        ),
     ],
 )
 def test_single_seed_invalid(fm_executor_env, contents, expected_error):
@@ -110,20 +112,29 @@ def test_single_seed_invalid(fm_executor_env, contents, expected_error):
 @pytest.mark.parametrize(
     "contents, iens, expected_error",
     [
-        ([""], 0, "Multi seed file is empty"),
-        (["1", "text"], 0, "Multi seed file contains non-number values"),
+        ([""], 0, "Multi seed file run_path/random.seeds is empty"),
+        (
+            ["1", "text"],
+            0,
+            "Multi seed file run_path/random.seeds contains non-number values",
+        ),
         (
             ["2", "1000"],
             0,
-            "Multi seed file has an incorrect number count value in line 1",
+            "Multi seed file run_path/random.seeds has an incorrect "
+            + "number count value in line 1, expected 1 but found 2",
         ),
-        (["0"], 0, "Multi seed file has no seed values"),
-        (["2", "1000", "1000"], 0, "Multi seed file contains non-unique seed values"),
+        (["0"], 0, "Multi seed file run_path/random.seeds has no seed values"),
+        (
+            ["2", "1000", "1000"],
+            0,
+            "Multi seed file run_path/random.seeds contains non-unique seed values",
+        ),
         (
             ["1", "1000"],
             1,
-            re.escape("Multi seed file has too few seed values (1) ")
-            + re.escape("for the needed realization number (2)"),
+            r"Multi seed file run_path/random.seeds has too few seed values \(1\) "
+            + r"for the needed realization number \(2\)",
         ),
     ],
 )


### PR DESCRIPTION
Resolves #9 

When validation of a single or multi seeds file fails, the error message now includes some additional information:
- Location of seeds file (path and filename)
- Brief description of file format
- Expected and actual count values when there is a mismatch
