### PR TITLE
DEP: Fully deprecate 'exec_env.json'

### DIFF
--- a/src/runrms/_forward_model.py
+++ b/src/runrms/_forward_model.py
@@ -45,10 +45,6 @@ class Rms(ForwardModelStepPlugin):  # type: ignore
                 "<RMS_OPTS>": "",
             },
             target_file="<RMS_TARGET_FILE>",
-            exec_env={
-                "PYTHONPATH": "<RMS_PYTHONPATH>",
-                "PATH_PREFIX": "<RMS_PATH_PREFIX>",
-            },
         )
 
     def validate_pre_realization_run(
@@ -74,6 +70,7 @@ class Rms(ForwardModelStepPlugin):  # type: ignore
 
 @plugin(name="runrms")  # type: ignore
 def forward_model_configuration() -> dict[str, dict[str, str]]:
+    """These exist for backward compatibility but have no effect."""
     return {
         Rms().name: {
             "RMS_PYTHONPATH": "<RMS_PYTHONPATH>",

--- a/src/runrms/config/_rms_config.py
+++ b/src/runrms/config/_rms_config.py
@@ -62,8 +62,7 @@ def _detect_os() -> str:
 def _load_site_config(site_config_file: str) -> SiteConfig:
     if not os.path.exists(site_config_file):
         raise RMSConfigNotFoundError(
-            "Unable to locate config file for rms\n"
-            f"{site_config_file} does not exist!"
+            f"Unable to locate config file for rms\n{site_config_file} does not exist!"
         )
     with open(site_config_file) as f:
         config = yaml.safe_load(f)

--- a/src/runrms/executor/_rms_executor.py
+++ b/src/runrms/executor/_rms_executor.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from copy import deepcopy
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from runrms.config import FMRMSConfig, InteractiveRMSConfig
@@ -22,70 +21,9 @@ class RMSExecutor(ABC):
 
     def __init__(self, config: InteractiveRMSConfig | FMRMSConfig) -> None:
         self._config = config
+        self._exec_env = self._init_exec_env()
 
-        # We want to append to or carry forward the following env vars
-        pre_env = {}
-        pre_env["PYTHONPATH"] = os.environ.get("PYTHONPATH", None)
-        pre_env["RMS_PLUGINS_LIBRARY"] = os.environ.get("RMS_PLUGINS_LIBRARY", None)
-        self._pre_env = {k: v for k, v in pre_env.items() if v}
-        self._exec_env: dict[str, str]
-
-        super().__init__()
-
-    @property
-    def config(self) -> InteractiveRMSConfig | FMRMSConfig:
-        return self._config
-
-    @property
-    def pre_env(self) -> dict[str, str]:
-        """Returns a dict containing a few specific environment variables we will
-        carry forward from before execution."""
-        return deepcopy(self._pre_env)
-
-    def _initialize_exec_env_from_config(self) -> None:
-        """Initializes the environment variables for the
-        execution environment of RMS."""
-        self._exec_env = self.pre_env
-        config_env = self._config_env()
-        for key, val in config_env.items():
-            self._update_exec_env(key, val, "config")
-
-    def _update_exec_env(
-        self, key: str, val: str, val_origin: Literal["config", "json", "test_config"]
-    ) -> None:
-        """Updates the environment variable with name `key` in the
-        execution environment of RMS with the value `val`.
-        Depending on the environment variable to update and the origin of `val`,
-        the entry will be updated in different ways. If the key does not match any
-        of the keys that needs special handling, the default case will add the value
-        to the front of the existing search path.
-        """
-        # TODO: Replace if/elif pattern below with a match case
-        # when all RMS versions support Python 3.10
-        if key == "RMS_PLUGINS_LIBRARY":
-            if val_origin == "json":
-                self._exec_env[key] = val
-            elif val_origin == "config":
-                if self._exec_env.get(key):
-                    return
-                self._exec_env[key] = val
-            elif val_origin == "test_config" and self._exec_env.get(key):
-                self._exec_env[key] = val
-                return
-        elif key == "LM_LICENSE_FILE":
-            self._exec_env[key] = val
-        elif key == "QT_SCALE_FACTOR":
-            self._exec_env[key] = str(val)
-        else:
-            # assert this is a PATH thing...
-            if key in self._exec_env:
-                self._exec_env[key] = f"{val}{os.pathsep}{self._exec_env[key]}"
-            else:
-                self._exec_env[key] = str(val)
-            if not self._exec_env[key].strip():
-                self._exec_env.pop(key)
-
-    def _config_env(self) -> dict[str, str]:
+    def _init_exec_env(self) -> dict[str, str]:
         """Returns a dict containing the key, value environment variable pairs from the
         configuration. This merges the top-level global configuration for all RMS
         versions as well as the specific RMS version environment variables. The default
@@ -100,6 +38,20 @@ class RMSExecutor(ABC):
         # Overwrite the global env if there are conflicts.
         config_env.update(version_env)
         return config_env
+
+    @property
+    def config(self) -> InteractiveRMSConfig | FMRMSConfig:
+        return self._config
+
+    def update_exec_env(self, key: str, val: str) -> None:
+        """Updates the environment variable with name `key` in the
+        execution environment of RMS with the value `val`."""
+        if key in ("PATH", "LD_LIBRARY_PATH"):
+            self._exec_env[key] = f"{val}{os.pathsep}{self._exec_env[key]}"
+        else:
+            self._exec_env[key] = val
+            if not self._exec_env[key].strip():
+                self._exec_env.pop(key)
 
     def pre_rms_args(self) -> list[str]:
         """The rms exec environement needs to be injected between executing the

--- a/src/runrms/executor/interactive_rms_executor.py
+++ b/src/runrms/executor/interactive_rms_executor.py
@@ -45,10 +45,7 @@ class InteractiveRMSExecutor(RMSExecutor):
 
     def _exec_rms(self) -> int:
         """Launch RMS with correct pythonpath, pluginspath etc."""
-        self._initialize_exec_env_from_config()
-        self._update_exec_env(
-            "QT_SCALE_FACTOR", str(self.config._dpi_scaling), "config"
-        )
+        self.update_exec_env("QT_SCALE_FACTOR", str(self.config._dpi_scaling))
         pre_args = self.pre_rms_args()
 
         args = [
@@ -156,7 +153,6 @@ class InteractiveRMSExecutor(RMSExecutor):
             print(fmt.format("RMS fileversion", self.config.project.master.fileversion))
             print(fmt.format("RMS variant", self.config.project.master.variant))
 
-        print(fmt.format("System PYTHONPATH", self.pre_env.get("PYTHONPATH", "")))
         order = "first"
         print(fmt.format(f"PYTHONPATH added as {order}", self.config.env.PYTHONPATH))
         print(fmt.format("RMS plugins path", self.config.env.RMS_PLUGINS_LIBRARY))

--- a/tests/bin/rms
+++ b/tests/bin/rms
@@ -5,7 +5,6 @@ import json
 import os
 import sys
 import time
-from typing import Optional
 
 config = {"exit_status": 0}
 if os.path.isfile("action.json"):
@@ -15,13 +14,13 @@ if os.path.isfile("action.json"):
 
 def write_target_file(target_file):
     with open(target_file, "w") as f:
-        f.write("this is the target file {}\n".format(time.time()))
+        f.write(f"this is the target file {time.time()}\n")
 
 
 if "target_file" in config:
     target_file = config["target_file"]
     if os.path.isfile(target_file):
-        mtime: Optional[float] = os.path.getmtime(target_file)
+        mtime: float | None = os.path.getmtime(target_file)
     else:
         mtime = None
 


### PR DESCRIPTION
In doing so, changed a bit of how the execution environment is set-up since we now only have to worry about modifying it from the configuration. This reduces some flexibility by preferring the configuration for important environment variables like `RMS_PLUGINS_LIBRARY` over existing environment variables, i.e. set before or because of ERT. The idea is that to change these one should use a fully different configuration rather than patch environment variables here and there. Increasing this strictness means that it is easier to ensure consistency and reproducibility.