### PR TITLE
Don't validate given number count value in random seeds file

### DIFF
--- a/src/runrms/config/fm_rms_config.py
+++ b/src/runrms/config/fm_rms_config.py
@@ -196,7 +196,11 @@ class FMRMSConfig(RMSConfig):
 
     @staticmethod
     def _validate_seed_source(
-        lines: list[str], filename: Path, is_multi: bool, iens_max: int | None = None
+        lines: list[str],
+        filename: Path,
+        is_multi: bool,
+        iens_max: int | None = None,
+        validate_given_number_count: bool = False,
     ) -> None:
         file_desc = "Multi seed file" if is_multi else "Single seed file"
         file_desc += f" {filename.absolute()}"
@@ -223,21 +227,23 @@ class FMRMSConfig(RMSConfig):
                 )
             return
 
-        number_count = int(lines[0])
+        given_number_count = int(lines[0])
         numbers = lines[1:]
-        if number_count != len(numbers):
+        actual_number_count = len(numbers)
+        if validate_given_number_count and given_number_count != actual_number_count:
             raise ValueError(
                 f"{file_desc} has an incorrect number count value in line 1, "
-                + f"expected {len(numbers)} but found {number_count}. {format_desc}"
+                f"expected {actual_number_count} but found {given_number_count}. "
+                f"{format_desc}"
             )
-        if number_count == 0:
+        if actual_number_count == 0:
             raise ValueError(f"{file_desc} has no seed values. {format_desc}")
-        if len(numbers) != len(set(numbers)):
+        if actual_number_count != len(set(numbers)):
             raise ValueError(
                 f"{file_desc} contains non-unique seed values. {format_desc}"
             )
-        if iens_max is not None and number_count <= iens_max:
+        if iens_max is not None and actual_number_count <= iens_max:
             raise ValueError(
-                f"{file_desc} has too few seed values ({number_count}) "
-                + f"for the needed realization number ({iens_max + 1})"
+                f"{file_desc} has too few seed values ({actual_number_count}) "
+                f"for the needed realization number ({iens_max + 1})"
             )

--- a/tests/test_fm_rms_config.py
+++ b/tests/test_fm_rms_config.py
@@ -114,12 +114,6 @@ def test_single_seed_invalid(fm_executor_env, contents, expected_error):
     [
         ([""], 0, r"Multi seed file \S+ is empty"),
         (["1", "text"], 0, r"Multi seed file \S+ contains non-number values"),
-        (
-            ["2", "1000"],
-            0,
-            r"Multi seed file \S+ has an incorrect number count value "
-            + "in line 1, expected 1 but found 2",
-        ),
         (["0"], 0, r"Multi seed file \S+ has no seed values"),
         (
             ["2", "1000", "1000"],


### PR DESCRIPTION
Resolves #19 

The validation of the given number count value in the `random.seeds` file (the value in the first line) is not done anymore. Note that the check is merely deactivated. The format of the file has not changed, and the description as shown to the user when any other error is found includes mention of the number count value. There is thus still code to perform the number count check, it's just deactivated through a parameter to the validation function. Should it be determined later that the check be reinstated, this can be controlled by this parameter. The corresponding test is removed though, as the test function cannot control this parameter.