### PR TITLE
ENH: Don't validate unique values in random seeds file

### DIFF
--- a/src/runrms/config/fm_rms_config.py
+++ b/src/runrms/config/fm_rms_config.py
@@ -195,12 +195,13 @@ class FMRMSConfig(RMSConfig):
         return True, None
 
     @staticmethod
-    def _validate_seed_source(
+    def _validate_seed_source(  # noqa: PLR0913
         lines: list[str],
         filename: Path,
         is_multi: bool,
         iens_max: int | None = None,
         validate_given_number_count: bool = False,
+        validate_unique_values: bool = False,
     ) -> None:
         file_desc = "Multi seed file" if is_multi else "Single seed file"
         file_desc += f" {filename.absolute()}"
@@ -238,7 +239,7 @@ class FMRMSConfig(RMSConfig):
             )
         if actual_number_count == 0:
             raise ValueError(f"{file_desc} has no seed values. {format_desc}")
-        if actual_number_count != len(set(numbers)):
+        if validate_unique_values and actual_number_count != len(set(numbers)):
             raise ValueError(
                 f"{file_desc} contains non-unique seed values. {format_desc}"
             )

--- a/tests/test_fm_rms_config.py
+++ b/tests/test_fm_rms_config.py
@@ -116,11 +116,6 @@ def test_single_seed_invalid(fm_executor_env, contents, expected_error):
         (["1", "text"], 0, r"Multi seed file \S+ contains non-number values"),
         (["0"], 0, r"Multi seed file \S+ has no seed values"),
         (
-            ["2", "1000", "1000"],
-            0,
-            r"Multi seed file \S+ contains non-unique seed values",
-        ),
-        (
             ["1", "1000"],
             1,
             r"Multi seed file \S+ has too few seed values \(1\) "


### PR DESCRIPTION
Resolves #24 

This removes validation of unique seed values. The description of the file still contains a requirement for non-unique values, but the validation function will no longer treat non-unique values as an error.

The validation checks that now remain correspond to how the seed values are treated by the code. The code expects the seed value to be an integer, and that the seed list contains a certain number of elements - at least two elements (the first element being a seed count), and at least a number of elements equal to the realization number (iens), if given.

The ignore code `PLR0913` is for the Ruff rule [too-many-arguments](https://docs.astral.sh/ruff/rules/too-many-arguments/). A new arguments has been added to `_validate_seed_source`, triggering this rule. It would have been possible to have one argument `options`, to replace the existing two arguments that enables or disables specific validation rules, but it would probably be overkill to implement such an argument (perhaps as an enum) for this function.