### PR TITLE
TYP: Do not import future annotations

### DIFF
--- a/.github/workflows/runrms.yml
+++ b/.github/workflows/runrms.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ruff check
         if: ${{ always() }}
-        run: ruff check 
+        run: ruff check
 
       - name: Ruff format
         if: ${{ always() }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check typing with mypy
         if: ${{ always() }}
-        run: mypy src
+        run: mypy src tests
 
       - name: Run tests
         if: ${{ always() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ convention = "google"
 combine-as-imports = true
 
 [tool.mypy]
-exclude = '(tests|build)'
+exclude = 'build'
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true

--- a/src/runrms/__main__.py
+++ b/src/runrms/__main__.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 import argparse
 import subprocess
 import sys
 
 from .config import FMRMSConfig, InteractiveRMSConfig
+from .exceptions import UnknownConfigError
 from .executor import FMRMSExecutor, InteractiveRMSExecutor
 
 try:
@@ -187,12 +186,6 @@ def get_parser() -> argparse.ArgumentParser:
     _add_fm_arguments(prs)
     _add_dev_arguments(prs)
     return prs
-
-
-class UnknownConfigError(Exception):
-    """
-    Custom error class for unknown config objects
-    """
 
 
 def generate_config(args: argparse.Namespace) -> FMRMSConfig | InteractiveRMSConfig:

--- a/src/runrms/_forward_model.py
+++ b/src/runrms/_forward_model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from ert import (  # type: ignore
     ForwardModelStepDocumentation,
     ForwardModelStepJSON,

--- a/src/runrms/_utils.py
+++ b/src/runrms/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/runrms/config/__init__.py
+++ b/src/runrms/config/__init__.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-from ._rms_config import (
-    DEFAULT_CONFIG_FILE,
-    RMSConfigNotFoundError,
-    RMSExecutableError,
-    RMSWrapperError,
-)
-from ._rms_project import RMSProjectNotFoundError
+from ._rms_config import DEFAULT_CONFIG_FILE
 from .fm_rms_config import FMRMSConfig
 from .interactive_rms_config import InteractiveRMSConfig
 
@@ -14,8 +8,4 @@ __all__ = [
     "DEFAULT_CONFIG_FILE",
     "FMRMSConfig",
     "InteractiveRMSConfig",
-    "RMSProjectNotFoundError",
-    "RMSConfigNotFoundError",
-    "RMSWrapperError",
-    "RMSExecutableError",
 ]

--- a/src/runrms/config/_rms_config.py
+++ b/src/runrms/config/_rms_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 import shutil
@@ -10,6 +8,13 @@ from typing import Final
 import yaml
 from packaging.version import parse as version_parse
 
+from runrms.exceptions import (
+    RMSConfigNotFoundError,
+    RMSExecutableError,
+    RMSVersionError,
+    RMSWrapperError,
+)
+
 from ._rms_project import RMSProject
 from ._site_config import Env, GlobalEnv, SiteConfig, Version
 
@@ -18,27 +23,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_FILE: Final = os.path.join(os.path.dirname(__file__), "runrms.yml")
 DEFAULT_VERSION: Final = "DEFAULT"
-
-
-class RMSConfigError(ValueError):
-    """Raised when the configuration file is errorneous."""
-
-
-class RMSConfigNotFoundError(FileNotFoundError):
-    """Raised when attempting to open a site configuration that does not exist."""
-
-
-class RMSExecutableError(OSError):
-    """Raised when the RMS executable cannot be executed, either because it's
-    not found or because of invalid user access to it."""
-
-
-class RMSWrapperError(FileNotFoundError):
-    """Raised when the RMS wrapper cannot be found."""
-
-
-class RMSVersionError(ValueError):
-    """Raised when the given rms version does not exist."""
 
 
 def _detect_os() -> str:

--- a/src/runrms/config/_rms_project.py
+++ b/src/runrms/config/_rms_project.py
@@ -1,12 +1,8 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
-
-class RMSProjectNotFoundError(OSError):
-    """Raised when attempting to open an RMS project that does not exist."""
+from runrms.exceptions import RMSProjectNotFoundError
 
 
 @dataclass
@@ -112,7 +108,7 @@ class RMSProject:
         return self.path.name
 
     @classmethod
-    def from_filepath(cls, project: str) -> RMSProject:
+    def from_filepath(cls, project: str) -> "RMSProject":
         project_path = Path(project)
         if not project_path.is_dir():
             raise RMSProjectNotFoundError(

--- a/src/runrms/config/_site_config.py
+++ b/src/runrms/config/_site_config.py
@@ -1,13 +1,8 @@
-from __future__ import annotations
-
 from pathlib import Path
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 from packaging.version import parse as version_parse
 from pydantic import BaseModel, Field, model_validator
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class Env(BaseModel):

--- a/src/runrms/config/fm_rms_config.py
+++ b/src/runrms/config/fm_rms_config.py
@@ -1,19 +1,13 @@
-from __future__ import annotations
-
+import argparse
 import logging
 import os
 import random
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from runrms.executor import RMSRuntimeError
+from runrms.exceptions import RMSRuntimeError
 
 from ._rms_config import RMSConfig
-
-if TYPE_CHECKING:
-    import argparse
-
-    from ._rms_project import RMSProject
+from ._rms_project import RMSProject
 
 logger = logging.getLogger(__name__)
 

--- a/src/runrms/config/interactive_rms_config.py
+++ b/src/runrms/config/interactive_rms_config.py
@@ -1,13 +1,8 @@
-from __future__ import annotations
-
+import argparse
 import logging
 import os
-from typing import TYPE_CHECKING
 
 from ._rms_config import RMSConfig
-
-if TYPE_CHECKING:
-    import argparse
 
 logger = logging.getLogger(__name__)
 

--- a/src/runrms/exceptions.py
+++ b/src/runrms/exceptions.py
@@ -1,0 +1,35 @@
+class RMSRuntimeError(Exception):
+    """
+    Custom error for run-time errors
+    """
+
+
+class UnknownConfigError(Exception):
+    """
+    Custom error class for unknown config objects
+    """
+
+
+class RMSProjectNotFoundError(OSError):
+    """Raised when attempting to open an RMS project that does not exist."""
+
+
+class RMSConfigError(ValueError):
+    """Raised when the configuration file is errorneous."""
+
+
+class RMSConfigNotFoundError(FileNotFoundError):
+    """Raised when attempting to open a site configuration that does not exist."""
+
+
+class RMSExecutableError(OSError):
+    """Raised when the RMS executable cannot be executed, either because it's
+    not found or because of invalid user access to it."""
+
+
+class RMSWrapperError(FileNotFoundError):
+    """Raised when the RMS wrapper cannot be found."""
+
+
+class RMSVersionError(ValueError):
+    """Raised when the given rms version does not exist."""

--- a/src/runrms/executor/__init__.py
+++ b/src/runrms/executor/__init__.py
@@ -1,9 +1,7 @@
-from ._rms_executor import RMSRuntimeError
 from .fm_rms_executor import FMRMSExecutor
 from .interactive_rms_executor import InteractiveRMSExecutor
 
 __all__ = [
     "FMRMSExecutor",
     "InteractiveRMSExecutor",
-    "RMSRuntimeError",
 ]

--- a/src/runrms/executor/_rms_executor.py
+++ b/src/runrms/executor/_rms_executor.py
@@ -1,17 +1,7 @@
-from __future__ import annotations
-
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from runrms.config import FMRMSConfig, InteractiveRMSConfig
-
-
-class RMSRuntimeError(Exception):
-    """
-    Custom error for run-time errors
-    """
+from runrms.config import FMRMSConfig, InteractiveRMSConfig
 
 
 class RMSExecutor(ABC):

--- a/src/runrms/executor/fm_rms_executor.py
+++ b/src/runrms/executor/fm_rms_executor.py
@@ -1,21 +1,17 @@
-from __future__ import annotations
-
 import glob
 import os
 import subprocess
 import sys
 import time
+from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
-from ._rms_executor import RMSExecutor, RMSRuntimeError
+from runrms.config.fm_rms_config import FMRMSConfig
+from runrms.exceptions import RMSRuntimeError
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-    from pathlib import Path
-
-    from runrms.config.fm_rms_config import FMRMSConfig
+from ._rms_executor import RMSExecutor
 
 
 @contextmanager

--- a/src/runrms/executor/interactive_rms_executor.py
+++ b/src/runrms/executor/interactive_rms_executor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 import getpass
 import logging
@@ -7,21 +5,18 @@ import platform
 import shutil
 import subprocess
 import time
-from typing import TYPE_CHECKING
 
 from runrms._utils import (
     BColors,
     xalert,
     xwarn,
 )
+from runrms.config.interactive_rms_config import (
+    InteractiveRMSConfig,
+)
 from runrms.version import __version__
 
 from ._rms_executor import RMSExecutor
-
-if TYPE_CHECKING:
-    from runrms.config.interactive_rms_config import (
-        InteractiveRMSConfig,
-    )
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,23 @@
 import sys
 from argparse import ArgumentError
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
 from runrms.__main__ import generate_config, get_parser, main
 
 
-def test_empty_invocation(executor_env, patch_argv) -> None:
+def test_empty_invocation(
+    executor_env: Path, patch_argv: Callable[[list[str]], None]
+) -> None:
     patch_argv(["--setup", "runrms.yml"])
     main()
 
 
-def test_invalid_batch_invocations(executor_env, patch_argv) -> None:
+def test_invalid_batch_invocations(
+    executor_env: Path, patch_argv: Callable[[list[str]], None]
+) -> None:
     patch_argv(["--setup", "runrms.yml", "--seed", "123"])
     with pytest.raises(ArgumentError, match="must be combined with --batch"):
         main()

--- a/tests/test_ert_fm_plugins.py
+++ b/tests/test_ert_fm_plugins.py
@@ -2,11 +2,14 @@ import json
 import re
 import shutil
 import subprocess
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
+from pytest import MonkeyPatch
 
 try:
-    from ert.plugins.plugin_manager import ErtPluginManager
+    from ert.plugins.plugin_manager import ErtPluginManager  # type: ignore
 except ImportError:
     pytest.skip(
         "Not testing ERT plugins when ERT is not installed", allow_module_level=True
@@ -19,7 +22,7 @@ EXPECTED_JOBS = {"RMS"}
 
 
 @pytest.mark.requires_ert
-def test_that_installable_fm_steps_work_as_plugins():
+def test_that_installable_fm_steps_work_as_plugins() -> None:
     """Test that the forward models are included as ERT plugin."""
     fms = ErtPluginManager(plugins=[ert_plugins]).forward_model_steps
 
@@ -28,7 +31,7 @@ def test_that_installable_fm_steps_work_as_plugins():
 
 
 @pytest.mark.requires_ert
-def test_fm_plugin_implementations():
+def test_fm_plugin_implementations() -> None:
     """Test hook implementation."""
     ert_pm = ErtPluginManager(plugins=[ert_plugins])
 
@@ -41,7 +44,7 @@ def test_fm_plugin_implementations():
 
 @pytest.mark.requires_ert
 @pytest.mark.integration
-def test_fm_plugin_executables():
+def test_fm_plugin_executables() -> None:
     """Test executables in the configured ert forward models."""
     ert_pm = ErtPluginManager(plugins=[ert_plugins])
     for fm_step in ert_pm.forward_model_steps:
@@ -49,7 +52,7 @@ def test_fm_plugin_executables():
 
 
 @pytest.mark.requires_ert
-def test_fm_plugin_docs():
+def test_fm_plugin_docs() -> None:
     """For each installed forward model, we require the associated
     description and example string to be nonempty,
     and the category to be as expected"""
@@ -65,7 +68,9 @@ def test_fm_plugin_docs():
 
 
 @pytest.mark.requires_ert
-def test_rms_forward_model_ok(tmp_path, monkeypatch, fmu_snakeoil_project):
+def test_rms_forward_model_ok(
+    tmp_path: Path, monkeypatch: MonkeyPatch, fmu_snakeoil_project: None
+) -> None:
     """Test that when running ert with the given configuration file,
     the rms forward model runs rms with the given arguments"""
     monkeypatch.chdir(tmp_path / "ert/model")
@@ -83,8 +88,11 @@ def test_rms_forward_model_ok(tmp_path, monkeypatch, fmu_snakeoil_project):
 
 @pytest.mark.requires_ert
 def test_rms_forward_model_seed_invalid(
-    tmp_path, monkeypatch, fmu_snakeoil_project, create_multi_seed_file
-):
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    fmu_snakeoil_project: None,
+    create_multi_seed_file: Callable[[str], None],
+) -> None:
     """Test that when the seed file used by RMS has an invalid format,
     the validation leads to an aborted run"""
     monkeypatch.chdir(tmp_path / "ert/model")

--- a/tests/test_fm_rms_config.py
+++ b/tests/test_fm_rms_config.py
@@ -1,12 +1,14 @@
-from __future__ import annotations
-
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from pytest import MonkeyPatch
 
 from runrms.config import (
     DEFAULT_CONFIG_FILE,
     FMRMSConfig,
+)
+from runrms.exceptions import (
     RMSProjectNotFoundError,
 )
 
@@ -27,14 +29,14 @@ def _mocked_args() -> Mock:
     return args
 
 
-def test_config_ok(fm_executor_env):
+def test_config_ok(fm_executor_env: Path) -> None:
     args = _mocked_args()
 
     config = FMRMSConfig(args)
     assert config is not None
 
 
-def test_missing_project():
+def test_missing_project() -> None:
     args = _mocked_args()
     args.project = "another_project"
 
@@ -43,7 +45,9 @@ def test_missing_project():
 
 
 @pytest.mark.parametrize("rms_seed", ["", "a", "123x"])
-def test_bad_seed_from_env_var(fm_executor_env, monkeypatch, rms_seed):
+def test_bad_seed_from_env_var(
+    fm_executor_env: Path, monkeypatch: MonkeyPatch, rms_seed: str
+) -> None:
     args = _mocked_args()
     monkeypatch.setenv("RMS_SEED", rms_seed)
 
@@ -59,7 +63,7 @@ def test_bad_seed_from_env_var(fm_executor_env, monkeypatch, rms_seed):
         (2, 422851785),
     ],
 )
-def test_single_seed_ok(fm_executor_env, iens, expected_result):
+def test_single_seed_ok(fm_executor_env: Path, iens: int, expected_result: int) -> None:
     args = _mocked_args()
     args.iens = iens
     contents = "422851785"
@@ -78,7 +82,7 @@ def test_single_seed_ok(fm_executor_env, iens, expected_result):
         (2, 132312123),
     ],
 )
-def test_multi_seed_ok(fm_executor_env, iens, expected_result):
+def test_multi_seed_ok(fm_executor_env: Path, iens: int, expected_result: int) -> None:
     args = _mocked_args()
     args.iens = iens
     contents = ["3", "422851785", "723121249", "132312123"]
@@ -100,7 +104,9 @@ def test_multi_seed_ok(fm_executor_env, iens, expected_result):
         ),
     ],
 )
-def test_single_seed_invalid(fm_executor_env, contents, expected_error):
+def test_single_seed_invalid(
+    fm_executor_env: Path, contents: str, expected_error: str
+) -> None:
     args = _mocked_args()
     with open("run_path/RMS_SEED", "w") as f:
         f.write(contents)
@@ -123,7 +129,9 @@ def test_single_seed_invalid(fm_executor_env, contents, expected_error):
         ),
     ],
 )
-def test_multi_seed_invalid(fm_executor_env, contents, iens, expected_error):
+def test_multi_seed_invalid(
+    fm_executor_env: Path, contents: list[str], iens: int, expected_error: str
+) -> None:
     args = _mocked_args()
     args.iens = iens
     with open("run_path/random.seeds", "w") as f:

--- a/tests/test_rms_project.py
+++ b/tests/test_rms_project.py
@@ -2,13 +2,14 @@ import shutil
 from pathlib import Path
 
 import pytest
+from pytest import MonkeyPatch
 
 from runrms.config._rms_project import (
     RMSProject,
-    RMSProjectNotFoundError,
     _parse_master_file_header,
     _sanitize_version,
 )
+from runrms.exceptions import RMSProjectNotFoundError
 
 
 @pytest.mark.parametrize(
@@ -25,27 +26,33 @@ def test_sanitize_version(given: str, expected: str) -> None:
     assert _sanitize_version(given) == expected
 
 
-def test_make_rmsproject_with_nonexistent_project_dir(tmp_path, monkeypatch) -> None:
+def test_make_rmsproject_with_nonexistent_project_dir(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     with pytest.raises(RMSProjectNotFoundError, match="does not exist as a directory"):
         RMSProject.from_filepath("notreal")
 
 
-def test_make_rmsproject_with_project_dir_as_file(tmp_path, monkeypatch) -> None:
+def test_make_rmsproject_with_project_dir_as_file(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     Path("notreal").touch()
     with pytest.raises(RMSProjectNotFoundError, match="does not exist as a directory"):
         RMSProject.from_filepath("notreal")
 
 
-def test_make_rmsproject_without_master_file(tmp_path, monkeypatch) -> None:
+def test_make_rmsproject_without_master_file(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     Path("notreal").mkdir()
     with pytest.raises(FileNotFoundError, match="RMS project .master file not found"):
         RMSProject.from_filepath("notreal")
 
 
-def test_rmsproject_parses_correct_master(source_root) -> None:
+def test_rmsproject_parses_correct_master(source_root: Path) -> None:
     drogon_master = source_root / "tests/testdata/rms/drogon.rms13.0.3/.master"
     master = _parse_master_file_header(drogon_master)
     assert master.version == "13.0.3"
@@ -56,9 +63,9 @@ def test_rmsproject_parses_correct_master(source_root) -> None:
     assert master.fileversion == "2021.0000"
 
 
-def test_make_rmsproject_without_lock(source_root) -> None:
+def test_make_rmsproject_without_lock(source_root: Path) -> None:
     drogon_master = source_root / "tests/testdata/rms/drogon.rms13.0.3"
-    rmsproject = RMSProject.from_filepath(drogon_master)
+    rmsproject = RMSProject.from_filepath(str(drogon_master))
     assert rmsproject.path == drogon_master
     assert rmsproject.name == "drogon.rms13.0.3"
     assert rmsproject.locked is False
@@ -71,7 +78,9 @@ def test_make_rmsproject_without_lock(source_root) -> None:
     assert rmsproject.master.fileversion == "2021.0000"
 
 
-def test_make_rmsproject_with_lock(tmp_path, monkeypatch, source_root) -> None:
+def test_make_rmsproject_with_lock(
+    tmp_path: Path, monkeypatch: MonkeyPatch, source_root: Path
+) -> None:
     test_path = tmp_path / "drogon.rms13.0.3"
     drogon_master = source_root / "tests/testdata/rms/drogon.rms13.0.3"
     shutil.copytree(drogon_master, test_path)
@@ -81,7 +90,7 @@ def test_make_rmsproject_with_lock(tmp_path, monkeypatch, source_root) -> None:
         "Locked by abc on s6.st.so.no with process id (pid) 123 at 2037.03.14 09:00:00"
     )
     Path("project_lock_file").write_text(lock_txt)
-    rmsproject = RMSProject.from_filepath(test_path)
+    rmsproject = RMSProject.from_filepath(str(test_path))
     assert rmsproject.path == test_path
     assert rmsproject.name == "drogon.rms13.0.3"
     assert rmsproject.locked is True

--- a/tests/test_runrms_entry_point.py
+++ b/tests/test_runrms_entry_point.py
@@ -1,13 +1,8 @@
-from __future__ import annotations
-
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from pytest import MonkeyPatch
+from pytest import MonkeyPatch
 
 
 def test_entry_point(


### PR DESCRIPTION
This is a maintenance PR prior to doing #4.

When removing future annotations circular import errors appeared from exceptions being imported here and there, so they were moved to an 'exceptions' module.