### PR TITLE
FIX: Hack around RMS versioning

### DIFF
--- a/src/runrms/config/_rms_config.py
+++ b/src/runrms/config/_rms_config.py
@@ -65,6 +65,12 @@ def _resolve_version(
         )
     if rms_project:
         if rms_project.master.version in site_config.versions:
+            # Handle RMS 14.5 specially as it stores no patch version whatsoever,
+            # whereas RMS 14.2 at least stored it via rmsapi. This is technically RMS
+            # 14.5.0 but RMS is currently unable to provide consistent versioning.
+            if rms_project.master.version == "14.5":
+                return rms_project.master.version
+
             master_version = version_parse(rms_project.master.version)
             major, minor, patch = master_version.release
 

--- a/src/runrms/config/_rms_project.py
+++ b/src/runrms/config/_rms_project.py
@@ -37,6 +37,10 @@ def _sanitize_version(version: str) -> str:
     if numdots == 0:
         return f"{version}.0.0"
     if numdots == 1:
+        # TODO: Remove this hack _if_ RMS
+        # can get its versioning act together.
+        if version == "14.5":
+            return version
         return f"{version}.0"
     return version
 

--- a/src/runrms/config/runrms.yml
+++ b/src/runrms/config/runrms.yml
@@ -38,9 +38,9 @@ versions:
       RMS_PLUGINS_LIBRARY: /opt/rms/14.2.2/site/plugins
       TCL_LIBRARY: /opt/rms/14.2.2/lib/tcl8.6
       TK_LIBRARY: /opt/rms/14.2.2/lib/tcl8.6
-  14.5.0:
+  "14.5":
     env:
-      PYTHONPATH: /opt/rms/14.5.0/site/lib/python3.11/site-packages
-      RMS_PLUGINS_LIBRARY: /opt/rms/14.5.0/site/plugins
-      TCL_LIBRARY: /opt/rms/14.5.0/lib/tcl8.6
-      TK_LIBRARY: /opt/rms/14.5.0/lib/tcl8.6
+      PYTHONPATH: /opt/rms/14.5/site/lib/python3.11/site-packages
+      RMS_PLUGINS_LIBRARY: /opt/rms/14.5/site/plugins
+      TCL_LIBRARY: /opt/rms/14.5/lib/tcl8.6
+      TK_LIBRARY: /opt/rms/14.5/lib/tcl8.6

--- a/tests/test_rms_config.py
+++ b/tests/test_rms_config.py
@@ -31,7 +31,7 @@ from runrms.exceptions import (
 def test_resolve_version(default_config_file: dict[str, Any]) -> None:
     site_config = SiteConfig.model_validate(default_config_file)
     assert _resolve_version("14.2.1", site_config, None) == "14.2.1"
-    assert _resolve_version("14.5.0", site_config, None) == "14.5.0"
+    assert _resolve_version("14.5", site_config, None) == "14.5"
     assert _resolve_version(None, site_config, None) == "14.2.2"
 
     with pytest.raises(
@@ -107,7 +107,7 @@ def test_init_rmsconfig_default_version(default_config_file: dict[str, Any]) -> 
     )
 
 
-@pytest.mark.parametrize("version", ["14.2.2", "14.5.0"])
+@pytest.mark.parametrize("version", ["14.2.2", "14.5"])
 def test_init_rmsconfig_given_version(
     default_config_file: dict[str, Any], version: str
 ) -> None:
@@ -210,7 +210,7 @@ def test_rmsconfig_get_env(
         ("14.2.1", "V14.2", "14.2.2"),
         ("14.2.2", "V14.2", "14.2.2"),
         ("14.2.1", "V14.2", "14.2.2"),
-        ("14.5.0", "V14.5", "14.5.0"),
+        ("14.5", "V14.5", "14.5"),
     ],
 )
 def test_rmsconfig_with_v14_from_master_resolves_to_latest_patch(


### PR DESCRIPTION
Resolves #33

This PR introduces hacks and technical debt in order to work around the current RMS versioning antipatterns. It will surely need to be followed by more hacks and technical debt depending on how the next version comes.

Tests adapted to this pattern.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=runrms --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
