### PR TITLE
FIX: Adjust RMS 14.5 handling for 14.5.0.1

### DIFF
--- a/src/runrms/config/_rms_config.py
+++ b/src/runrms/config/_rms_config.py
@@ -65,17 +65,12 @@ def _resolve_version(
         )
     if rms_project:
         if rms_project.master.version in site_config.versions:
-            # Handle RMS 14.5 specially as it stores no patch version whatsoever,
-            # whereas RMS 14.2 at least stored it via rmsapi. This is technically RMS
-            # 14.5.0 but RMS is currently unable to provide consistent versioning.
-            if rms_project.master.version == "14.5":
-                return rms_project.master.version
-
             master_version = version_parse(rms_project.master.version)
-            major, minor, patch = master_version.release
+            major = master_version.major
+            minor = master_version.minor
 
-            # Handle RMS 14 specially as it stores no patch version internally.
-            if major == 14:
+            # Handle RMS 14.2 specially as it stores no patch version internally.
+            if major == 14 and minor <= 2:
                 newest_patch = site_config.get_newest_patch_version(major, minor)
                 return f"{major}.{minor}.{newest_patch}"
 

--- a/src/runrms/config/runrms.yml
+++ b/src/runrms/config/runrms.yml
@@ -44,3 +44,9 @@ versions:
       RMS_PLUGINS_LIBRARY: /opt/rms/14.5/site/plugins
       TCL_LIBRARY: /opt/rms/14.5/lib/tcl8.6
       TK_LIBRARY: /opt/rms/14.5/lib/tcl8.6
+  14.5.0.1:
+    env:
+      PYTHONPATH: /opt/rms/14.5.0.1/site/lib/python3.11/site-packages
+      RMS_PLUGINS_LIBRARY: /opt/rms/14.5.0.1/site/plugins
+      TCL_LIBRARY: /opt/rms/14.5.0.1/lib/tcl8.6
+      TK_LIBRARY: /opt/rms/14.5.0.1/lib/tcl8.6

--- a/tests/test_rms_config.py
+++ b/tests/test_rms_config.py
@@ -32,6 +32,7 @@ def test_resolve_version(default_config_file: dict[str, Any]) -> None:
     site_config = SiteConfig.model_validate(default_config_file)
     assert _resolve_version("14.2.1", site_config, None) == "14.2.1"
     assert _resolve_version("14.5", site_config, None) == "14.5"
+    assert _resolve_version("14.5.0.1", site_config, None) == "14.5.0.1"
     assert _resolve_version(None, site_config, None) == "14.2.2"
 
     with pytest.raises(
@@ -211,6 +212,7 @@ def test_rmsconfig_get_env(
         ("14.2.2", "V14.2", "14.2.2"),
         ("14.2.1", "V14.2", "14.2.2"),
         ("14.5", "V14.5", "14.5"),
+        ("14.5.0.1", "V14.5.0.1", "14.5.0.1"),
     ],
 )
 def test_rmsconfig_with_v14_from_master_resolves_to_latest_patch(


### PR DESCRIPTION
Resolves #35

This simplifies some earlier handling as well by not unpacking the version values.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=runrms --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
