### PR TITLE
TST: Add some proxy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ norecursedirs = [
     "dist",
     "build",
 ]
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers --basetemp=/tmp/pytest"
 markers = [
     "integration: Marks a test as an integration test",
     "onprem: Marks a test as valid only in an on-prem environment",

--- a/src/runrms/api/proxy.py
+++ b/src/runrms/api/proxy.py
@@ -269,7 +269,7 @@ class RmsApiProxy:
     def __str__(self) -> str:
         """Forward string conversion to worker."""
         if not self._path:
-            return f"<RmsApiProxy connected to {self._zmq_address}"
+            return f"<RmsApiProxy connected to {self._zmq_address}>"
 
         request = Request(msg_type="call", path=[*self._path, "__str__"])
         response = self._send_request(request)
@@ -278,7 +278,7 @@ class RmsApiProxy:
     def __repr__(self) -> str:
         """Forward repr conversion to worker."""
         if not self._path:
-            return f"<RmsApiProxy connected to {self._zmq_address}"
+            return f"<RmsApiProxy connected to {self._zmq_address}>"
 
         request = Request(msg_type="call", path=[*self._path, "__repr__"])
         response = self._send_request(request)

--- a/tests/test_api/test_proxy.py
+++ b/tests/test_api/test_proxy.py
@@ -73,6 +73,12 @@ def test_private_attr_raises(proxy_with_mocks: RmsApiProxy) -> None:
         _ = proxy_with_mocks._private
 
 
+def test_str_repr_on_root_proxy_gives_instance(proxy_with_mocks: RmsApiProxy) -> None:
+    """Str and repr print the root RmsApiProxy instance with its address."""
+    assert str(proxy_with_mocks).startswith("<RmsApiProxy connected to ipc://")
+    assert repr(proxy_with_mocks).startswith("<RmsApiProxy connected to ipc://")
+
+
 def test_version_special_case(
     proxy_with_mocks: RmsApiProxy, mock_socket: MagicMock
 ) -> None:
@@ -495,6 +501,13 @@ def test_shutdown_sends_request(
     sent_data = mock_socket.send.call_args[0][0]
     request = Request.deserialize(sent_data)
     assert request.msg_type == "shutdown"
+
+
+def test_shutdown_on_child_proxy_raises(proxy_with_mocks: RmsApiProxy) -> None:
+    """Accessing attribute returns new proxy with extended path."""
+    child = proxy_with_mocks.some_attr
+    with pytest.raises(RuntimeError, match="Shutdown can only be called on root"):
+        child._shutdown()
 
 
 def test_cleanup_closes_socket(


### PR DESCRIPTION
Part of #48. The worker tests require more work.

- `--basetemp=/tmp/pytest"` to work around long pytest paths that cause zmq to fail

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=runrms --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
